### PR TITLE
Switch extension to GPT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A **Chrome extension** that takes custom screenshots, **extracts text**, and all
 
 1. **Custom Screenshots**: Capture screenshots from Chrome.
 2. **Text Extraction**: Extract text from screenshots using Tesseract OCR.
-3. **Ask Questions**: Use Google Gemini API to ask questions based on extracted text.
+3. **Ask Questions**: Use the OpenAI GPT API to ask questions based on extracted text.
 4. **User Preferences**: Configure language and accuracy settings for OCR.
 5. **Interactive OCR Results**: View and interact with extracted text by copying it, saving it, or saving the screenshot.
 
@@ -28,19 +28,19 @@ A **Chrome extension** that takes custom screenshots, **extracts text**, and all
 ![Screenshot (38)](https://github.com/user-attachments/assets/50ce95f2-0f29-4594-8326-f98ac3c07a8b)
 
 </br></br>
-`Step 3:` Fill *Google Gemini* API key and ask related *question*
+`Step 3:` Fill *OpenAI GPT* API key and ask related *question*
 <br>
-Prerequisite: `Google Gemini API`
+Prerequisite: `OpenAI GPT API`
 </br>
 
 ![Screenshot (39)](https://github.com/user-attachments/assets/cf75db26-a63c-40d5-8dd0-3976b80076de)
 
 </br></br>
-## Steps to get Gemini API key
- - Sign up at `https://ai.google.dev/aistudio`
- 
-   
- - Click on `Get API key`
+## Steps to get OpenAI API key
+ - Sign up at `https://platform.openai.com/signup`
+
+
+ - Visit `https://platform.openai.com/account/api-keys` and create a new key
 <img src ="https://github.com/gitgoap/AI-Snipping-Tool/assets/117789470/9ae60e18-1966-4550-9ebc-59c468dec70c" height= 250 >
 
 
@@ -233,7 +233,7 @@ https://github.com/user-attachments/assets/a8769d70-4d1e-4b93-a2f5-7692ab313b3f
 # Future Scope / Features
 
 - [ ] **YouTube Video Screenshot:** Capture text in the current YouTube video frame with just one click of a popup button.
-- [ ] **Answers questions just with screenshots:** This feature is possible by utilizing the multimodal feature of Google Gemini.
+- [ ] **Answers questions just with screenshots:** This feature will be possible by utilizing the multimodal capabilities of OpenAI GPT models.
 
 
   ![image](https://github.com/gitgoap/HackFest-24-IIT-Dhanbad/assets/117789470/1592f070-2e07-436b-b268-dc25be5e8e53)

--- a/inject/elements.js
+++ b/inject/elements.js
@@ -461,7 +461,7 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
         <input type="text" placeholder="Ask a question" id="prompt">
         </br>
         <label for="api-key-section">API Key
-            <a href="https://aistudio.google.com/app/apikey" title="Get API Key" style="text-decoration: none;">
+            <a href="https://platform.openai.com/account/api-keys" title="Get API Key" style="text-decoration: none;">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
                     <polyline points="15 3 21 3 21 9"></polyline>
@@ -471,7 +471,7 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
         </label>
 
         <div id="api-key-section">
-            <input type="text" placeholder="Enter your Gemini API key" id="key">
+            <input type="text" placeholder="Enter your OpenAI API key" id="key">
             <button id="save-key">Save</button>
         </div>
     </div>
@@ -805,8 +805,8 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
                   }.bind(this));
 
                 // Enter saved API Key in the API Key input field.
-                chrome.storage.local.get('gemini-api-key', function(result) {
-                    const API_KEY = result['gemini-api-key'];
+                chrome.storage.local.get('openai-api-key', function(result) {
+                    const API_KEY = result['openai-api-key'];
                     if (API_KEY !== undefined) { 
                         // Check if API_KEY is not undefined
                         const apiKeyField = this.shadowRoot.querySelector('#key');
@@ -943,20 +943,22 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
                     this.shadowRoot.getElementById('summary-area').style.display = 'none';
                     this.shadowRoot.getElementById('answer-heading').style.display = 'none';
                   
-                    fetch(`https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash:generateContent?key=${API_KEY}`, {
+                    fetch('https://api.openai.com/v1/chat/completions', {
                       method: 'POST',
                       headers: {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${API_KEY}`
                       },
                       body: JSON.stringify({
-                        "contents": [
-                          { "parts": [{ "text": question }] }
+                        model: 'gpt-3.5-turbo',
+                        messages: [
+                          { role: 'user', content: question }
                         ]
                       })
                     })
                     .then(response => response.json())
                     .then(data => {
-                      const generatedSummary = data.candidates[0].content.parts[0].text;
+                      const generatedSummary = data.choices[0].message.content;
                       const summaryArea = this.shadowRoot.getElementById('summary-area');
                       summaryArea.textContent = generatedSummary;
                       
@@ -975,7 +977,7 @@ Use Ctrl + Click or Command + Click to remove local language training data`,
                 // Save API Key
                 this.shadowRoot.getElementById('save-key').onclick = e => {
                     var API_KEY = this.shadowRoot.getElementById('key').value;
-                    chrome.storage.local.set({ 'gemini-api-key': API_KEY }, function() {
+                    chrome.storage.local.set({ 'openai-api-key': API_KEY }, function() {
                     console.log(API_KEY);
                     });
                 };


### PR DESCRIPTION
## Summary
- replace Gemini API references with OpenAI's GPT API
- update documentation for GPT API usage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866cd8aabf083318c62656dd208cd8a